### PR TITLE
Support for registering connections

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -89,16 +89,13 @@ class IRCConnection(object):
             sys.exit(1)
         
         self._sock_file = self._sock.makefile()
-        
-        self.send('USER %s %s bla :%s' % (self.nick, self.server, self.nick), True)
+        self.register()        
+    
+    def register(self):
         self.logger.info('Authing as %s' % self.nick)
-        
-        # send NICK command as soon as authing
-        self.register_nick()
-    
-    def register_nick(self):
         self.send('NICK %s' % self.nick, True)
-    
+        self.send('USER %s %s bla :%s' % (self.nick, self.server, self.nick), True)
+
     def join(self, channel):
         channel = channel.lstrip('#')
         self.send('JOIN #%s' % channel)


### PR DESCRIPTION
Hey,

Really like the module. Got the simple bot I wanted running 35 lines, which is really cool!

Anyway, some servers (like the ones running newnet) wont accept incoming commands before the connection is completely registered. The calls to conn.join thus resulted in error messages from the server because they were sent too early.

I've added support for waiting for the connection to be registered before sending any data. The algorithm for determining if a connection is registered is done by waiting for the end of the motd (or abscence of motd). I stole that from here http://search.cpan.org/dist/AnyEvent-IRC/lib/AnyEvent/IRC/Client.pm#EVENTS

Please pull if the patches look sane to you.

Cheers

Rune
