### PR TITLE
add /privmsg to filter for privmsg

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -200,7 +200,7 @@ class IRCConnection(object):
         results = []
         
         for pattern, callback in self._callbacks:
-            match = pattern.match(message)
+            match = pattern.match(message) or pattern.match('/privmsg')
             if match:
                 results.append(callback(nick, message, channel, **match.groupdict()))
         


### PR DESCRIPTION
This allows one to get only privmsg both channel and private without getting parts/joins/etc. Works the same way as parts/joins/etc

``` python
def command_patterns(self):
    return (
        ('/privmsg', self.do_privmsg),
        ('/part', self.do_part),
        ('/quit', self.do_quit),
    )
```
